### PR TITLE
Release v1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.VERSION }}"
+          VERSION_NUMBER="${VERSION#v}"
+
+          # Extract section for this version from CHANGELOG.md
+          if grep -q "## \[${VERSION_NUMBER}\]" CHANGELOG.md; then
+            awk "/## \[${VERSION_NUMBER}\]/,/^## \[/" CHANGELOG.md | sed '$d' | tail -n +2 > release_notes.md
+          else
+            echo "Release ${VERSION}" > release_notes.md
+            echo "" >> release_notes.md
+            echo "See [CHANGELOG.md](CHANGELOG.md) for details." >> release_notes.md
+          fi
+
+          # Add installation instructions
+          echo "" >> release_notes.md
+          echo "---" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "## Installation" >> release_notes.md
+          echo "" >> release_notes.md
+          echo '```bash' >> release_notes.md
+          echo "composer require agenziasmart/swotto" >> release_notes.md
+          echo '```' >> release_notes.md
+          echo "" >> release_notes.md
+          echo "## Documentation" >> release_notes.md
+          echo "" >> release_notes.md
+          echo "- [README](https://github.com/agenziasmart/swotto#readme)" >> release_notes.md
+          echo "- [CHANGELOG](https://github.com/agenziasmart/swotto/blob/master/CHANGELOG.md)" >> release_notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.version.outputs.VERSION }}
+          body_path: release_notes.md
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify success
+        run: |
+          echo "✅ Release ${{ steps.version.outputs.VERSION }} created successfully!"
+          echo "📦 Packagist will auto-update within a few minutes"

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ Thumbs.db
 !.gitkeep
 !.editorconfig
 !.gitattributes
-!.github
 
 # Claude Code files and directories
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 !.gitkeep
 !.editorconfig
 !.gitattributes
+!.github
 
 # Claude Code files and directories
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-10-16
+
+### Fixed
+
+- **Circuit Breaker False Positives**: Fixed critical bug where circuit breaker was incorrectly incrementing failure count for 4xx client errors (401 Unauthorized, 403 Forbidden, 404 Not Found, 422 Validation, 429 Rate Limit)
+- Circuit breaker now correctly increments ONLY for 5xx server errors (500, 502, 503, 504) and network failures (NetworkException, ConnectionException)
+- Prevents authentication and validation errors from incorrectly triggering circuit breaker state transitions
+- Added comprehensive test coverage (11 new tests, 23 new assertions) to validate correct behavior
+
+### Technical Details
+
+- Test Coverage: 89 tests (was 78), 234 assertions (was 211)
+- All quality checks passing: PSR-12, PHPStan Level 8
+
+---
+
 ## [1.0.0] - 2025-10-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Swotto simplifies API integration with built-in authentication, error handling, 
 - [Configuration Reference](#configuration-reference)
 - [Testing](#testing)
 - [FAQ](#faq)
+- [Advanced FAQ](#advanced-faq)
 - [Support](#support)
 - [License](#license)
 
@@ -614,6 +615,561 @@ $client->setLogger($yourPsr3Logger);
 ### Can I use this with Laravel/Symfony/other frameworks?
 
 Yes! Swotto is framework-agnostic and works with any PHP application.
+
+## Advanced FAQ
+
+<details>
+<summary><strong>📊 Response Methods & Data Handling</strong></summary>
+
+### What's the difference between `get()`, `getParsed()`, and `getResponse()`?
+
+**`get()` [RECOMMENDED]**: Returns the response exactly as provided by the SW4 API. Pattern aligned with AWS SDK, Twilio, Stripe - maximum predictability.
+
+```php
+$response = $client->get('customers');
+$customers = $response['data'];
+$totalPages = $response['meta']['pagination']['total_pages'];
+```
+
+**`getParsed()`**: Optional helper that transforms `meta.pagination` into a `paginator` object with additional calculated fields (e.g., `range` array for UI pagination). Use only if you need this convenience.
+
+```php
+$parsed = $client->getParsed('customers');
+$paginator = $parsed['paginator']; // with 'range', 'current', 'last' pre-calculated
+```
+
+**`getResponse()`**: For multi-format content (CSV, PDF, binary). Returns `SwottoResponse` object with methods like `isPdf()`, `isCsv()`, `saveToFile()`.
+
+```php
+$response = $client->getResponse('exports/report');
+if ($response->isPdf()) {
+    $response->saveToFile('/path/to/file.pdf');
+}
+```
+
+### When should I use `getParsed()` instead of `get()`?
+
+Use `getParsed()` only if:
+- You're building pagination UI and want pre-calculated `range` array
+- You prefer `paginator['current']` instead of `meta['pagination']['current_page']`
+
+For all other cases, **use `get()`** - ensures what you read in SW4 API documentation matches exactly what you receive in the SDK.
+
+### How do I handle pagination with `get()`?
+
+```php
+$response = $client->get('customers', ['query' => ['page' => 1, 'limit' => 50]]);
+
+$customers = $response['data'];
+$pagination = $response['meta']['pagination'];
+
+echo "Page {$pagination['current_page']} of {$pagination['total_pages']}";
+echo "Total: {$pagination['total']} customers";
+
+// Next page
+if ($pagination['current_page'] < $pagination['total_pages']) {
+    $nextPage = $client->get('customers', [
+        'query' => ['page' => $pagination['current_page'] + 1]
+    ]);
+}
+```
+
+### Can I automatically iterate through all pages?
+
+```php
+function fetchAllPages($client, $endpoint) {
+    $allData = [];
+    $page = 1;
+
+    do {
+        $response = $client->get($endpoint, [
+            'query' => ['page' => $page, 'limit' => 100]
+        ]);
+        $allData = array_merge($allData, $response['data']);
+
+        $pagination = $response['meta']['pagination'] ?? null;
+        $page++;
+
+    } while ($pagination && $page <= $pagination['total_pages']);
+
+    return $allData;
+}
+```
+
+</details>
+
+<details>
+<summary><strong>🔐 Authentication & Multi-tenancy</strong></summary>
+
+### Can I use the SDK without a DevApp token?
+
+No. The DevApp token is **required** for all requests. It identifies your application and determines which SW4 organization you have access to.
+
+```php
+// ❌ Fails with AuthenticationException
+$client = new Client(['url' => 'https://api.sw4.it']);
+
+// ✅ Correct
+$client = new Client([
+    'url' => 'https://api.sw4.it',
+    'key' => $_ENV['SW4_DEVAPP_TOKEN']
+]);
+```
+
+### How do I get a DevApp token?
+
+1. Log in to your SW4 account: `https://app.sw4.it`
+2. Go to **Settings → DevApps**
+3. Create a new application and copy the token
+4. **Never** commit the token - use environment variables
+
+### What's the purpose of the Bearer token if I already have a DevApp token?
+
+**DevApp token** = identifies YOUR application (required)
+**Bearer token** = identifies the END USER using your app (optional)
+
+```php
+// Your SaaS app has 1000 end users
+$client = new Client([
+    'key' => 'YOUR_APP_DEVAPP_TOKEN' // identifies your app
+]);
+
+// User1 logs in to your app
+$client->setAccessToken($user1Token); // identifies User1
+$orders1 = $client->get('orders'); // sees User1's orders
+
+// User2 logs in
+$client->setAccessToken($user2Token); // switch to User2
+$orders2 = $client->get('orders'); // sees User2's orders
+```
+
+### Is data isolated between organizations?
+
+Yes! **Multi-tenancy guaranteed**:
+- DevApp token determines the organization (`_oid`)
+- All data automatically filtered for that organization
+- Impossible to access other organizations' data even with valid Bearer token
+
+**Isolation priority**: DevApp `_oid` **always overrides** User/Account `_oid`.
+
+</details>
+
+<details>
+<summary><strong>📁 File Operations</strong></summary>
+
+### How do I upload a single file with metadata?
+
+```php
+$fileHandle = fopen('/path/to/document.pdf', 'r');
+
+$response = $client->postFile(
+    'documents',
+    $fileHandle,
+    'attachment', // form field name
+    [
+        'title' => 'Contract 2025',
+        'category' => 'legal',
+        'tags' => ['contract', 'important']
+    ]
+);
+
+fclose($fileHandle);
+echo "Document ID: {$response['data']['id']}";
+```
+
+### How do I upload multiple files simultaneously?
+
+```php
+$files = [
+    'invoice' => fopen('/path/to/invoice.pdf', 'r'),
+    'receipt' => fopen('/path/to/receipt.jpg', 'r'),
+    'contract' => fopen('/path/to/contract.pdf', 'r'),
+];
+
+$response = $client->postFiles('documents/batch', $files, [
+    'batch_name' => 'January 2025 Documents',
+    'category' => 'accounting'
+]);
+
+// Close all files
+foreach ($files as $handle) {
+    fclose($handle);
+}
+```
+
+### How does Swotto handle very large files?
+
+Automatic streaming:
+- **< 10MB**: in-memory loading (fast)
+- **> 10MB**: automatic streaming (memory-safe)
+- **> 50MB**: `MemoryException` thrown (protection)
+
+For large downloads, use `downloadToFile()` instead of `get()`:
+
+```php
+// ❌ 200MB file loaded in memory = crash
+$bigFile = $client->get('exports/huge-dataset.csv');
+
+// ✅ Direct download to disk = memory-safe
+$client->downloadToFile('exports/huge-dataset.csv', '/path/to/file.csv');
+```
+
+### Can I update only the file without touching metadata?
+
+```php
+// PATCH = update only file, metadata remains
+$newFile = fopen('/path/to/updated.pdf', 'r');
+$client->patchFile('documents/123', $newFile);
+
+// PUT = replace everything (file + metadata reset)
+$client->putFile('documents/123', $newFile);
+```
+
+</details>
+
+<details>
+<summary><strong>⚡ Circuit Breaker Pattern</strong></summary>
+
+### What is Circuit Breaker and when should I use it?
+
+Resilience pattern that prevents "cascading failures" when the SW4 API has issues.
+
+**States**:
+1. **CLOSED**: API ok → normal requests
+2. **OPEN**: API failed N times → block all requests (fail-fast)
+3. **HALF_OPEN**: after timeout → test with 1 request
+
+**When to enable:**
+- ✅ Production environment
+- ✅ Critical external APIs where API downtime shouldn't crash your app
+- ❌ Development/testing (unnecessary overhead)
+
+### How do I enable Circuit Breaker?
+
+```php
+use Swotto\Client;
+use Swotto\Http\GuzzleHttpClient;
+use Swotto\Config\Configuration;
+
+$config = [
+    'url' => 'https://api.sw4.it',
+    'key' => $_ENV['SW4_DEVAPP_TOKEN'],
+    'circuit_breaker_enabled' => true,
+    'circuit_breaker_failure_threshold' => 5,   // OPEN after 5 failures
+    'circuit_breaker_recovery_timeout' => 30,   // retry after 30s
+];
+
+// Requires PSR-16 cache (Redis, Memcached, etc.)
+$cache = new \Symfony\Component\Cache\Psr16Cache(
+    new \Symfony\Component\Cache\Adapter\RedisAdapter($redisClient)
+);
+
+$client = new Client(
+    $config,
+    $logger,
+    GuzzleHttpClient::withCircuitBreaker(
+        new Configuration($config),
+        $logger,
+        $cache
+    ),
+    $cache
+);
+```
+
+### What happens when the circuit breaker is OPEN?
+
+```php
+use Swotto\Exception\CircuitBreakerOpenException;
+
+try {
+    $response = $client->get('customers');
+} catch (CircuitBreakerOpenException $e) {
+    // API temporarily unavailable
+    $retryAfter = $e->getRetryAfter(); // seconds
+
+    // Show user-friendly message
+    echo "Service temporarily unavailable. Retry in {$retryAfter} seconds.";
+
+    // Or use cached data
+    $customers = $cachedData;
+}
+```
+
+</details>
+
+<details>
+<summary><strong>📊 POP Methods (Lookup Data)</strong></summary>
+
+### What are POPs and when should I use them?
+
+POP = "lookup data" from SW4 (dropdowns, select options). Examples: countries, languages, currencies, genders.
+
+27+ pre-configured helper methods with **automatic 1-hour cache**:
+
+```php
+// Country list for dropdown
+$countries = $client->getCountryPop();
+foreach ($countries as $country) {
+    echo "<option value='{$country['code']}'>{$country['name']}</option>";
+}
+
+// Gender options
+$genders = $client->getGenderPop();
+
+// Currencies
+$currencies = $client->getCurrencyPop();
+
+// System languages
+$languages = $client->getSysLanguagePop();
+
+// Customer/Supplier for autocomplete
+$customers = $client->getCustomerPop();
+$suppliers = $client->getSupplierPop();
+```
+
+### Do POP methods make HTTP requests every time?
+
+No! **Automatic PSR-16 cache for 1 hour**:
+- First call: HTTP request → cache
+- Subsequent calls (< 1h): read from cache
+- After 1h: cache expired → new HTTP request
+
+**Requires**: PSR-16 cache injected in the client (Redis, Memcached, APCu, File).
+
+### What's the complete list of available POPs?
+
+```php
+// Geographic
+$client->getCountryPop();
+$client->getContinentPop();
+$client->getProvincePop();
+
+// Master data
+$client->getGenderPop();
+$client->getCustomerPop();
+$client->getSupplierPop();
+
+// System
+$client->getSysLanguagePop();
+$client->getCurrencyPop();
+$client->getWarehousePop();
+$client->getDocumentTypePop();
+
+// Business
+$client->getPaymentMethodPop();
+$client->getShippingMethodPop();
+$client->getTaxRatePop();
+
+// ... total 27+ methods
+// Complete list: see PopTrait or SW4 API docs
+```
+
+</details>
+
+<details>
+<summary><strong>🛡️ Error Handling</strong></summary>
+
+### How do I handle validation errors (422)?
+
+```php
+use Swotto\Exception\ValidationException;
+
+try {
+    $response = $client->post('customers', [
+        'email' => 'invalid-email', // missing @
+        'age' => 'twenty' // must be number
+    ]);
+} catch (ValidationException $e) {
+    $errors = $e->getErrorData();
+
+    // $errors = [
+    //     'email' => ['The email field must be a valid email address.'],
+    //     'age' => ['The age field must be a number.']
+    // ]
+
+    foreach ($errors as $field => $messages) {
+        echo "{$field}: " . implode(', ', (array)$messages) . "\n";
+    }
+}
+```
+
+### How do I implement retry with exponential backoff?
+
+```php
+use Swotto\Exception\{NetworkException, RateLimitException};
+
+function retryRequest($client, $endpoint, $maxRetries = 3) {
+    $attempt = 0;
+    $baseDelay = 1; // seconds
+
+    while ($attempt < $maxRetries) {
+        try {
+            return $client->get($endpoint);
+
+        } catch (RateLimitException $e) {
+            // Use API's Retry-After header
+            sleep($e->getRetryAfter());
+
+        } catch (NetworkException $e) {
+            // Exponential backoff: 1s, 2s, 4s, 8s
+            $delay = $baseDelay * (2 ** $attempt);
+            sleep($delay);
+            $attempt++;
+        }
+    }
+
+    throw new \Exception("Max retries ({$maxRetries}) exceeded");
+}
+```
+
+### What's the complete exception hierarchy?
+
+```
+SwottoExceptionInterface
+└── SwottoException (base)
+    ├── ApiException (HTTP 400-599)
+    │   ├── AuthenticationException (401)
+    │   ├── ForbiddenException (403)
+    │   ├── NotFoundException (404)
+    │   ├── ValidationException (422)
+    │   └── RateLimitException (429)
+    ├── NetworkException (connectivity)
+    │   └── ConnectionException
+    ├── SecurityException
+    │   ├── FileOperationException (path traversal, etc.)
+    │   └── MemoryException (>50MB)
+    └── CircuitBreakerOpenException
+```
+
+**Best practice**: catch from specific to generic.
+
+### How do I log all requests for debugging?
+
+```php
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('swotto');
+$logger->pushHandler(new StreamHandler('/var/log/swotto.log', Logger::DEBUG));
+
+$client = new Client(['url' => '...', 'key' => '...']);
+$client->setLogger($logger);
+
+// Automatically logs:
+// - Request: method, URI, headers (without tokens!), body
+// - Response: status, body
+// - Errors: complete exceptions
+```
+
+</details>
+
+<details>
+<summary><strong>⚙️ Performance & Best Practices</strong></summary>
+
+### How do I reduce the number of API calls?
+
+1. **Local cache** for static data (POPs, configurations)
+2. **Batch requests** where available (`postFiles`)
+3. **Efficient pagination** (reasonable limits: 50-100 records/page)
+4. **Circuit breaker** in production (prevents retry storms)
+5. **PSR-16 cache** for POP methods (reduce 1000+ calls → 1 call/hour)
+
+### Can I make parallel HTTP requests?
+
+Yes! Use Guzzle async:
+
+```php
+use GuzzleHttp\Promise;
+
+// Prepare promises
+$promises = [
+    'customers' => $httpClient->requestAsync('GET', 'customers'),
+    'orders' => $httpClient->requestAsync('GET', 'orders'),
+    'products' => $httpClient->requestAsync('GET', 'products'),
+];
+
+// Execute in parallel
+$results = Promise\Utils::unwrap($promises);
+
+// Use results
+$customers = $results['customers'];
+$orders = $results['orders'];
+```
+
+**Note**: Swotto Client doesn't expose async methods directly - you must use the underlying HttpClient.
+
+### How do I handle development vs production environments?
+
+```php
+// config/swotto.php
+return [
+    'development' => [
+        'url' => 'https://api-dev.sw4.it',
+        'key' => $_ENV['SW4_DEV_TOKEN'],
+        'verify' => false, // self-signed SSL ok
+        'timeout' => 120, // longer debug timeout
+        'circuit_breaker_enabled' => false,
+    ],
+    'production' => [
+        'url' => 'https://api.sw4.it',
+        'key' => $_ENV['SW4_PROD_TOKEN'],
+        'verify' => true, // strict SSL
+        'timeout' => 30,
+        'circuit_breaker_enabled' => true,
+        'circuit_breaker_failure_threshold' => 5,
+        'circuit_breaker_recovery_timeout' => 30,
+    ],
+];
+
+// Bootstrap
+$env = $_ENV['APP_ENV'] ?? 'production';
+$config = require 'config/swotto.php';
+$client = new Client($config[$env]);
+```
+
+### Is Swotto thread-safe for multi-threaded applications?
+
+**Client object**: No, not thread-safe. Each thread must create its own Client instance.
+
+```php
+// ❌ Don't share between threads
+$sharedClient = new Client($config);
+
+// ✅ Create instance per thread
+function worker($config) {
+    $client = new Client($config);
+    // ... use $client only in this thread
+}
+```
+
+**PSR-16 cache**: Depends on implementation (Redis/Memcached = thread-safe, APCu = no).
+
+### How do I integrate Swotto with Laravel?
+
+```php
+// config/services.php
+'swotto' => [
+    'url' => env('SW4_API_URL'),
+    'key' => env('SW4_DEVAPP_TOKEN'),
+],
+
+// app/Providers/AppServiceProvider.php
+use Swotto\Client;
+
+public function register() {
+    $this->app->singleton(Client::class, function ($app) {
+        return new Client(config('services.swotto'));
+    });
+}
+
+// Controller usage
+public function index(Client $swotto) {
+    $customers = $swotto->get('customers');
+    return view('customers', compact('customers'));
+}
+```
+
+</details>
 
 ## Support
 

--- a/tests/CircuitBreakerHttpClientTest.php
+++ b/tests/CircuitBreakerHttpClientTest.php
@@ -10,7 +10,15 @@ use Psr\Log\NullLogger;
 use Swotto\CircuitBreaker\CircuitBreaker;
 use Swotto\CircuitBreaker\CircuitBreakerHttpClient;
 use Swotto\Contract\HttpClientInterface;
+use Swotto\Exception\ApiException;
+use Swotto\Exception\AuthenticationException;
 use Swotto\Exception\CircuitBreakerOpenException;
+use Swotto\Exception\ConnectionException;
+use Swotto\Exception\ForbiddenException;
+use Swotto\Exception\NetworkException;
+use Swotto\Exception\NotFoundException;
+use Swotto\Exception\RateLimitException;
+use Swotto\Exception\ValidationException;
 
 /**
  * CircuitBreakerHttpClientTest.
@@ -19,6 +27,9 @@ use Swotto\Exception\CircuitBreakerOpenException;
  */
 class CircuitBreakerHttpClientTest extends TestCase
 {
+    /**
+     * @var HttpClientInterface&\Mockery\MockInterface
+     */
     private HttpClientInterface $mockClient;
 
     private CircuitBreaker $circuitBreaker;
@@ -27,6 +38,7 @@ class CircuitBreakerHttpClientTest extends TestCase
 
     protected function setUp(): void
     {
+        /** @phpstan-ignore-next-line */
         $this->mockClient = Mockery::mock(HttpClientInterface::class);
         $this->circuitBreaker = new CircuitBreaker(
             name: 'test',
@@ -37,7 +49,7 @@ class CircuitBreakerHttpClientTest extends TestCase
             logger: new NullLogger()
         );
         $this->circuitBreakerClient = new CircuitBreakerHttpClient(
-            $this->mockClient,
+            $this->mockClient, // @phpstan-ignore-line
             $this->circuitBreaker
         );
     }
@@ -91,5 +103,260 @@ class CircuitBreakerHttpClientTest extends TestCase
             ->shouldNotReceive('request');
 
         $this->circuitBreakerClient->request('GET', '/test', []);
+    }
+
+    // ========== 4xx CLIENT ERRORS - SHOULD NOT INCREMENT CIRCUIT BREAKER ==========
+
+    public function test401UnauthorizedDoesNotIncrementCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/auth', [])
+            ->andThrow(new AuthenticationException('Unauthorized', [], 401));
+
+        $this->expectException(AuthenticationException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/auth', []);
+        } catch (AuthenticationException $e) {
+            // Circuit breaker should NOT increment for 401
+            $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function test403ForbiddenDoesNotIncrementCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/admin', [])
+            ->andThrow(new ForbiddenException('Forbidden', [], 403));
+
+        $this->expectException(ForbiddenException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/admin', []);
+        } catch (ForbiddenException $e) {
+            // Circuit breaker should NOT increment for 403
+            $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function test404NotFoundDoesNotIncrementCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/not-exists', [])
+            ->andThrow(new NotFoundException('Not Found', [], 404));
+
+        $this->expectException(NotFoundException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/not-exists', []);
+        } catch (NotFoundException $e) {
+            // Circuit breaker should NOT increment for 404
+            $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function test422ValidationDoesNotIncrementCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('POST', '/auth/account', [])
+            ->andThrow(new ValidationException('Validation failed', ['email' => 'required'], 422));
+
+        $this->expectException(ValidationException::class);
+
+        try {
+            $this->circuitBreakerClient->request('POST', '/auth/account', []);
+        } catch (ValidationException $e) {
+            // Circuit breaker should NOT increment for 422
+            $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function test429RateLimitDoesNotIncrementCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/resource', [])
+            ->andThrow(new RateLimitException('Too Many Requests', [], 60));
+
+        $this->expectException(RateLimitException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/resource', []);
+        } catch (RateLimitException $e) {
+            // Circuit breaker should NOT increment for 429
+            $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    // ========== 5xx SERVER ERRORS - SHOULD INCREMENT CIRCUIT BREAKER ==========
+
+    public function test500ServerErrorIncrementsCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/resource', [])
+            ->andThrow(new ApiException('Internal Server Error', [], 500));
+
+        $this->expectException(ApiException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/resource', []);
+        } catch (ApiException $e) {
+            // Circuit breaker SHOULD increment for 500
+            $this->assertEquals(1, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function test503ServiceUnavailableIncrementsCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/resource', [])
+            ->andThrow(new ApiException('Service Unavailable', [], 503));
+
+        $this->expectException(ApiException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/resource', []);
+        } catch (ApiException $e) {
+            // Circuit breaker SHOULD increment for 503
+            $this->assertEquals(1, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    // ========== NETWORK ERRORS - SHOULD INCREMENT CIRCUIT BREAKER ==========
+
+    public function testNetworkExceptionIncrementsCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/resource', [])
+            ->andThrow(new NetworkException('Network error', [], 0));
+
+        $this->expectException(NetworkException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/resource', []);
+        } catch (NetworkException $e) {
+            // Circuit breaker SHOULD increment for network errors
+            $this->assertEquals(1, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    public function testConnectionExceptionIncrementsCircuitBreaker(): void
+    {
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/resource', [])
+            ->andThrow(new ConnectionException('Connection failed', 'https://api.example.com', [], 0));
+
+        $this->expectException(ConnectionException::class);
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/resource', []);
+        } catch (ConnectionException $e) {
+            // Circuit breaker SHOULD increment for connection errors
+            $this->assertEquals(1, $this->circuitBreaker->getFailureCount());
+            throw $e;
+        }
+    }
+
+    // ========== MULTIPLE 4xx DO NOT OPEN CIRCUIT ==========
+
+    public function testMultiple4xxErrorsDoNotOpenCircuit(): void
+    {
+        // First 401
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/auth', [])
+            ->andThrow(new AuthenticationException('Unauthorized', [], 401));
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/auth', []);
+        } catch (AuthenticationException $e) {
+            // Expected
+        }
+
+        $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+
+        // Second 422
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('POST', '/data', [])
+            ->andThrow(new ValidationException('Validation failed', [], 422));
+
+        try {
+            $this->circuitBreakerClient->request('POST', '/data', []);
+        } catch (ValidationException $e) {
+            // Expected
+        }
+
+        // Circuit breaker should still be at 0 - circuit remains CLOSED
+        $this->assertEquals(0, $this->circuitBreaker->getFailureCount());
+    }
+
+    // ========== MULTIPLE 5xx OPEN CIRCUIT ==========
+
+    public function testMultiple5xxErrorsOpenCircuit(): void
+    {
+        // First 500 (threshold = 2 in setUp)
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/1', [])
+            ->andThrow(new ApiException('Internal Server Error', [], 500));
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/1', []);
+        } catch (ApiException $e) {
+            // Expected
+        }
+
+        $this->assertEquals(1, $this->circuitBreaker->getFailureCount());
+
+        // Second 503 - should OPEN circuit
+        $this->mockClient
+            ->shouldReceive('request')
+            ->once()
+            ->with('GET', '/api/2', [])
+            ->andThrow(new ApiException('Service Unavailable', [], 503));
+
+        try {
+            $this->circuitBreakerClient->request('GET', '/api/2', []);
+        } catch (ApiException $e) {
+            // Expected
+        }
+
+        $this->assertEquals(2, $this->circuitBreaker->getFailureCount());
+
+        // Third request should be blocked by OPEN circuit
+        $this->mockClient
+            ->shouldNotReceive('request');
+
+        $this->expectException(CircuitBreakerOpenException::class);
+        $this->circuitBreakerClient->request('GET', '/api/3', []);
     }
 }


### PR DESCRIPTION
 ### Critical Bug Fix

  Fixed circuit breaker false positives where 4xx client errors (401, 403, 404, 422, 429) were incorrectly incrementing the failure counter.

  ### Changes

  - Circuit breaker now correctly increments ONLY for:
    - 5xx server errors (500, 502, 503, 504)
    - Network failures (NetworkException, ConnectionException)

  - Circuit breaker correctly ignores:
    - 401 Unauthorized (authentication issues)
    - 403 Forbidden (authorization issues)
    - 404 Not Found (resource not found)
    - 422 Unprocessable Entity (validation errors)
    - 429 Too Many Requests (rate limiting)

  ### Testing

  - Added 11 comprehensive tests
  - Total: 89 tests, 234 assertions (all passing)
  - PSR-12 compliant
  - PHPStan Level 8 passing

  ### Impact

  Prevents authentication/authorization/validation errors from incorrectly triggering circuit breaker state transitions.