### PR TITLE
feat: complete ClientInterface with missing public methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-01-06
+
+### Added
+
+- Add `getResponse()` method to `ClientInterface` for advanced response handling (CSV, PDF, binary)
+- Add `downloadToFile()` method to `ClientInterface` for direct file downloads with security validation
+- Add `setClientUserAgent()` method to `ClientInterface` for forwarding client metadata
+- Add `setClientIp()` method to `ClientInterface` for forwarding client metadata
+
+### Notes
+
+- `ClientInterface` now exposes all public methods from `Client`, enabling proper mocking in tests
+- No breaking changes - existing code continues to work without modifications
+
+---
+
 ## [1.0.4] - 2025-12-09
 
 ### Security

--- a/src/Contract/ClientInterface.php
+++ b/src/Contract/ClientInterface.php
@@ -287,4 +287,45 @@ interface ClientInterface
         array $metadata = [],
         array $options = []
     ): array;
+
+    /**
+     * Set client original user agent for X-Client-User-Agent header.
+     *
+     * @param string $userAgent Original client user agent
+     * @return void
+     */
+    public function setClientUserAgent(string $userAgent): void;
+
+    /**
+     * Set client original IP for X-Client-Ip header.
+     *
+     * @param string $ip Original client IP
+     * @return void
+     */
+    public function setClientIp(string $ip): void;
+
+    /**
+     * Get response as SwottoResponse object for advanced content handling.
+     *
+     * @param string $uri The URI to request
+     * @param array $options Request options to apply
+     * @return \Swotto\Response\SwottoResponse Smart response wrapper
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getResponse(string $uri, array $options = []): \Swotto\Response\SwottoResponse;
+
+    /**
+     * Download content directly to file with security validation.
+     *
+     * @param string $uri The URI to request
+     * @param string $filePath Destination file path
+     * @param array $options Request options to apply
+     * @return bool True on successful download
+     *
+     * @throws \Swotto\Exception\SecurityException If path validation fails
+     * @throws \Swotto\Exception\FileOperationException If file operations fail
+     * @throws \Swotto\Exception\SwottoException On other errors
+     */
+    public function downloadToFile(string $uri, string $filePath, array $options = []): bool;
 }


### PR DESCRIPTION
## Summary

Complete `ClientInterface` with four methods that were already implemented in `Client` but missing from the interface contract:

- `setClientUserAgent()`: forward client user agent header
- `setClientIp()`: forward client IP header  
- `getResponse()`: advanced response handling for CSV/PDF/binary
- `downloadToFile()`: secure file download with validation

## Motivation

In v1.0.4, `final` was added to `Client` class for encapsulation. However, `ClientInterface` did not expose all public methods, making it impossible to properly mock the interface in consumer tests.

This change enables interface-based mocking while maintaining the design decision to keep `Client` final.

## Changes

- Add 4 methods to `ClientInterface` (44 lines)
- Update CHANGELOG for v1.1.0

## Test Plan

- [x] PHPStan Level 8: 0 errors
- [x] PHPUnit: 98 tests, 290 assertions
- [x] PSR-12: Compliant
- [ ] Review code changes

## Notes

- No breaking changes
- Semantic versioning: minor bump (1.0.4 → 1.1.0)