### PR TITLE
Release v1.1.0: Complete ClientInterface with POP methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `downloadToFile()` method to `ClientInterface` for direct file downloads with security validation
 - Add `setClientUserAgent()` method to `ClientInterface` for forwarding client metadata
 - Add `setClientIp()` method to `ClientInterface` for forwarding client metadata
+- Add 24 POP (lookup data) methods to `ClientInterface`:
+  - **Enum-based lookups**: `getGenderPop()`, `getUserRolePop()`, `getShiptypePop()`
+  - **System lookups**: `getCountryPop()`, `getSysLanguagePop()`, `getCurrencyPop()`
+  - **Entity lookups**: `getCustomerPop()`, `getSupplierPop()`, `getProductPop()`, `getCarrierPop()`, `getCategoryPop()`, `getWarehousePop()`, `getWarehouseZonePop()`, `getProjectPop()`, `getTemplatePop()`, `getFamilyPop()`, `getAgreementPop()`
+  - **Specialized lookups**: `getIncotermPop()`, `getIncotermByCode()`, `getPaymentType()`, `getWhsreasonPop()`, `getWhsinboundPop()`, `getWhsorderPop()`
+  - **Organization**: `getMeOrganization()`
 
 ### Notes
 
-- `ClientInterface` now exposes all public methods from `Client`, enabling proper mocking in tests
+- `ClientInterface` now exposes all public methods from `Client` and `PopTrait`, enabling proper mocking in tests
+- Applications can now type-hint `ClientInterface` instead of concrete `Client` class for dependency injection
 - No breaking changes - existing code continues to work without modifications
 
 ---

--- a/src/Contract/ClientInterface.php
+++ b/src/Contract/ClientInterface.php
@@ -328,4 +328,246 @@ interface ClientInterface
      * @throws \Swotto\Exception\SwottoException On other errors
      */
     public function downloadToFile(string $uri, string $filePath, array $options = []): bool;
+
+    // =========================================================================
+    // POP (Lookup Data) Methods
+    // =========================================================================
+
+    /**
+     * Get gender POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getGenderPop(?array $query = []): array;
+
+    /**
+     * Get user role POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getUserRolePop(?array $query = []): array;
+
+    /**
+     * Get current user's organization data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array Organization data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getMeOrganization(?array $query = []): array;
+
+    /**
+     * Get country POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getCountryPop(?array $query = []): array;
+
+    /**
+     * Get system language POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getSysLanguagePop(?array $query = []): array;
+
+    /**
+     * Get currency POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getCurrencyPop(?array $query = []): array;
+
+    /**
+     * Get customer POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getCustomerPop(?array $query = []): array;
+
+    /**
+     * Get template POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getTemplatePop(?array $query = []): array;
+
+    /**
+     * Get incoterm POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getIncotermPop(?array $query = []): array;
+
+    /**
+     * Get incoterm by code.
+     *
+     * @param string $code Incoterm code
+     * @return array Incoterm data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getIncotermByCode(string $code): array;
+
+    /**
+     * Get carrier POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getCarrierPop(?array $query = []): array;
+
+    /**
+     * Get category POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getCategoryPop(?array $query = []): array;
+
+    /**
+     * Get supplier POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getSupplierPop(?array $query = []): array;
+
+    /**
+     * Get warehouse POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getWarehousePop(?array $query = []): array;
+
+    /**
+     * Get warehouse zone POP data by warehouse ID.
+     *
+     * @param int $id Warehouse ID
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getWarehouseZonePop(int $id, ?array $query = []): array;
+
+    /**
+     * Get project POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getProjectPop(?array $query = []): array;
+
+    /**
+     * Get product POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getProductPop(?array $query = []): array;
+
+    /**
+     * Get payment type POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getPaymentType(?array $query = []): array;
+
+    /**
+     * Get agreement POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getAgreementPop(?array $query = []): array;
+
+    /**
+     * Get warehouse reason POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getWhsreasonPop(?array $query = []): array;
+
+    /**
+     * Get warehouse inbound POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getWhsinboundPop(?array $query = []): array;
+
+    /**
+     * Get warehouse order POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getWhsorderPop(?array $query = []): array;
+
+    /**
+     * Get family POP data.
+     *
+     * @param array|null $query Additional query parameters
+     * @return array POP data
+     *
+     * @throws \Swotto\Exception\SwottoException On error
+     */
+    public function getFamilyPop(?array $query = []): array;
+
+    /**
+     * Get ship type POP data.
+     *
+     * @return array POP data (static list: Vettore, Mittente, Destinatario)
+     */
+    public function getShiptypePop(): array;
 }


### PR DESCRIPTION
## Summary

- Add 24 POP (lookup data) methods to `ClientInterface`
- Complete the interface contract to match all public methods from `Client` + `PopTrait`
- Enable proper mocking in tests when type-hinting against interface

## Changes

### ClientInterface additions (24 methods)

| Category | Methods |
|----------|---------|
| Enum-based | `getGenderPop()`, `getUserRolePop()`, `getShiptypePop()` |
| System | `getCountryPop()`, `getSysLanguagePop()`, `getCurrencyPop()` |
| Entity | `getCustomerPop()`, `getSupplierPop()`, `getProductPop()`, `getCarrierPop()`, `getCategoryPop()`, `getWarehousePop()`, `getWarehouseZonePop()`, `getProjectPop()`, `getTemplatePop()`, `getFamilyPop()`, `getAgreementPop()` |
| Specialized | `getIncotermPop()`, `getIncotermByCode()`, `getPaymentType()`, `getWhsreasonPop()`, `getWhsinboundPop()`, `getWhsorderPop()` |
| Organization | `getMeOrganization()` |

## Quality Checks

- [x] PHPStan Level 8: 0 errors
- [x] PSR-12 Code Style: Pass
- [x] PHPUnit: 98 tests, 290 assertions

## Breaking Changes

None - this is a non-breaking addition to the interface.

## Post-Merge

After merging, create tag `v1.1.0` on master to trigger the release.