### PR TITLE
Stateless per-call options for worker-mode safety

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -158,25 +158,49 @@ final class Client implements ClientInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated 3.0.0 Pass session_id in per-call options instead for worker-mode safety.
+     *             Example: $client->get('uri', ['session_id' => $sessionId])
      */
     public function setSessionId(string $sessionId): void
     {
+        @trigger_error(
+            'setSessionId() is deprecated since Swotto 3.0. '
+            . 'Pass session_id in per-call options instead: $client->get($uri, [\'session_id\' => $sessionId])',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['session_id' => $sessionId]);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated 3.0.0 Pass language in per-call options instead for worker-mode safety.
+     *             Example: $client->get('uri', ['language' => $language])
      */
     public function setLanguage(string $language): void
     {
+        @trigger_error(
+            'setLanguage() is deprecated since Swotto 3.0. '
+            . 'Pass language in per-call options instead: $client->get($uri, [\'language\' => $language])',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['language' => $language]);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated 3.0.0 Pass accept in request headers instead for worker-mode safety.
+     *             Example: $client->get('uri', ['headers' => ['Accept' => $accept]])
      */
     public function setAccept(string $accept): void
     {
+        @trigger_error(
+            'setAccept() is deprecated since Swotto 3.0. '
+            . 'Pass accept header in per-call options instead.',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['accept' => $accept]);
     }
 
@@ -207,9 +231,17 @@ final class Client implements ClientInterface
      *
      * @param string $userAgent Original client user agent
      * @return void
+     *
+     * @deprecated 3.0.0 Pass client_user_agent in per-call options instead for worker-mode safety.
+     *             Example: $client->get('uri', ['client_user_agent' => $userAgent])
      */
     public function setClientUserAgent(string $userAgent): void
     {
+        @trigger_error(
+            'setClientUserAgent() is deprecated since Swotto 3.0. '
+            . 'Pass client_user_agent in per-call options instead: $client->get($uri, [\'client_user_agent\' => $ua])',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['client_user_agent' => $userAgent]);
     }
 
@@ -218,9 +250,17 @@ final class Client implements ClientInterface
      *
      * @param string $ip Original client IP
      * @return void
+     *
+     * @deprecated 3.0.0 Pass client_ip in per-call options instead for worker-mode safety.
+     *             Example: $client->get('uri', ['client_ip' => $ip])
      */
     public function setClientIp(string $ip): void
     {
+        @trigger_error(
+            'setClientIp() is deprecated since Swotto 3.0. '
+            . 'Pass client_ip in per-call options instead: $client->get($uri, [\'client_ip\' => $ip])',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['client_ip' => $ip]);
     }
 
@@ -383,9 +423,17 @@ final class Client implements ClientInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated 3.0.0 Pass bearer_token in per-call options instead for worker-mode safety.
+     *             Example: $client->get('uri', ['bearer_token' => $token])
      */
     public function setAccessToken(string $token): void
     {
+        @trigger_error(
+            'setAccessToken() is deprecated since Swotto 3.0. '
+            . 'Pass bearer_token in per-call options instead: $client->get($uri, [\'bearer_token\' => $token])',
+            E_USER_DEPRECATED
+        );
         $this->updateConfig(['access_token' => $token]);
     }
 

--- a/src/Contract/ClientInterface.php
+++ b/src/Contract/ClientInterface.php
@@ -15,7 +15,14 @@ interface ClientInterface
      * Send a GET request.
      *
      * @param string $uri The URI to request
-     * @param array $options Request options to apply
+     * @param array $options Request options to apply. Supports Swotto per-call options:
+     *   - bearer_token: (string) Override Authorization header for this request (worker-safe)
+     *   - language: (string) Override Accept-Language for this request
+     *   - session_id: (string) Override x-sid header for this request
+     *   - client_ip: (string) Set Client-Ip header for this request
+     *   - client_user_agent: (string) Set User-Agent for this request
+     *   - query: (array) Query parameters
+     *   - headers: (array) Additional headers (merged with above, lower priority)
      * @return array The response data
      *
      * @throws \Swotto\Exception\SwottoException On error
@@ -27,7 +34,13 @@ interface ClientInterface
      *
      * @param string $uri The URI to request
      * @param mixed $data Data to send (array for JSON auto-detection, or resource for file)
-     * @param array $options Request options to apply (optional)
+     * @param array $options Request options. Supports Swotto per-call options:
+     *   - bearer_token: (string) Override Authorization header for this request (worker-safe)
+     *   - language: (string) Override Accept-Language for this request
+     *   - session_id: (string) Override x-sid header for this request
+     *   - client_ip: (string) Set Client-Ip header for this request
+     *   - client_user_agent: (string) Set User-Agent for this request
+     *   - headers: (array) Additional headers (merged with above, lower priority)
      * @return array The response data
      *
      * @throws \Swotto\Exception\SwottoException On error
@@ -39,7 +52,13 @@ interface ClientInterface
      *
      * @param string $uri The URI to request
      * @param mixed $data Data to send (array for JSON auto-detection, or resource for file)
-     * @param array $options Request options to apply (optional)
+     * @param array $options Request options. Supports Swotto per-call options:
+     *   - bearer_token: (string) Override Authorization header for this request (worker-safe)
+     *   - language: (string) Override Accept-Language for this request
+     *   - session_id: (string) Override x-sid header for this request
+     *   - client_ip: (string) Set Client-Ip header for this request
+     *   - client_user_agent: (string) Set User-Agent for this request
+     *   - headers: (array) Additional headers (merged with above, lower priority)
      * @return array The response data
      *
      * @throws \Swotto\Exception\SwottoException On error
@@ -51,7 +70,13 @@ interface ClientInterface
      *
      * @param string $uri The URI to request
      * @param mixed $data Data to send (array for JSON auto-detection, or resource for file)
-     * @param array $options Request options to apply (optional)
+     * @param array $options Request options. Supports Swotto per-call options:
+     *   - bearer_token: (string) Override Authorization header for this request (worker-safe)
+     *   - language: (string) Override Accept-Language for this request
+     *   - session_id: (string) Override x-sid header for this request
+     *   - client_ip: (string) Set Client-Ip header for this request
+     *   - client_user_agent: (string) Set User-Agent for this request
+     *   - headers: (array) Additional headers (merged with above, lower priority)
      * @return array The response data
      *
      * @throws \Swotto\Exception\SwottoException On error
@@ -62,7 +87,13 @@ interface ClientInterface
      * Send a DELETE request.
      *
      * @param string $uri The URI to request
-     * @param array $options Request options to apply
+     * @param array $options Request options. Supports Swotto per-call options:
+     *   - bearer_token: (string) Override Authorization header for this request (worker-safe)
+     *   - language: (string) Override Accept-Language for this request
+     *   - session_id: (string) Override x-sid header for this request
+     *   - client_ip: (string) Set Client-Ip header for this request
+     *   - client_user_agent: (string) Set User-Agent for this request
+     *   - headers: (array) Additional headers (merged with above, lower priority)
      * @return array The response data
      *
      * @throws \Swotto\Exception\SwottoException On error
@@ -103,6 +134,8 @@ interface ClientInterface
      *
      * @param string $sessionId The session ID
      * @return void
+     *
+     * @deprecated 3.0.0 Pass session_id in per-call options instead for worker-mode safety.
      */
     public function setSessionId(string $sessionId): void;
 
@@ -111,6 +144,8 @@ interface ClientInterface
      *
      * @param string $language The language code
      * @return void
+     *
+     * @deprecated 3.0.0 Pass language in per-call options instead for worker-mode safety.
      */
     public function setLanguage(string $language): void;
 
@@ -119,6 +154,8 @@ interface ClientInterface
      *
      * @param string $accept The accept header value
      * @return void
+     *
+     * @deprecated 3.0.0 Pass accept header in per-call options instead for worker-mode safety.
      */
     public function setAccept(string $accept): void;
 
@@ -196,6 +233,8 @@ interface ClientInterface
      *
      * @param string $token The access token (Bearer token)
      * @return void
+     *
+     * @deprecated 3.0.0 Pass bearer_token in per-call options instead for worker-mode safety.
      */
     public function setAccessToken(string $token): void;
 
@@ -303,6 +342,8 @@ interface ClientInterface
      *
      * @param string $userAgent Original client user agent
      * @return void
+     *
+     * @deprecated 3.0.0 Pass client_user_agent in per-call options instead for worker-mode safety.
      */
     public function setClientUserAgent(string $userAgent): void;
 
@@ -311,6 +352,8 @@ interface ClientInterface
      *
      * @param string $ip Original client IP
      * @return void
+     *
+     * @deprecated 3.0.0 Pass client_ip in per-call options instead for worker-mode safety.
      */
     public function setClientIp(string $ip): void;
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -119,23 +119,37 @@ class ConfigurationTest extends TestCase
         $this->assertArrayNotHasKey('x-sid', $headers);
     }
 
-    public function testDetectClientUserAgent(): void
+    public function testGetClientUserAgent(): void
     {
         $config = new Configuration([
             'url' => 'https://api.example.com',
             'client_user_agent' => 'TestAgent/1.0',
         ]);
 
-        $this->assertEquals('TestAgent/1.0', $config->detectClientUserAgent());
+        $this->assertEquals('TestAgent/1.0', $config->getClientUserAgent());
     }
 
-    public function testDetectClientIp(): void
+    public function testGetClientUserAgentReturnsNullWhenNotConfigured(): void
+    {
+        $config = new Configuration(['url' => 'https://api.example.com']);
+
+        $this->assertNull($config->getClientUserAgent());
+    }
+
+    public function testGetClientIp(): void
     {
         $config = new Configuration([
             'url' => 'https://api.example.com',
             'client_ip' => '192.168.1.1',
         ]);
 
-        $this->assertEquals('192.168.1.1', $config->detectClientIp());
+        $this->assertEquals('192.168.1.1', $config->getClientIp());
+    }
+
+    public function testGetClientIpReturnsNullWhenNotConfigured(): void
+    {
+        $config = new Configuration(['url' => 'https://api.example.com']);
+
+        $this->assertNull($config->getClientIp());
     }
 }

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -89,7 +89,7 @@ class EdgeCasesTest extends TestCase
             'client_user_agent' => "MyApp/1.0\r\nX-Injected: malicious",
         ]);
 
-        $userAgent = $config->detectClientUserAgent();
+        $userAgent = $config->getClientUserAgent();
         $this->assertNotNull($userAgent);
 
         // CRLF should be stripped
@@ -108,7 +108,7 @@ class EdgeCasesTest extends TestCase
             'client_ip' => "192.168.1.1\r\nX-Injected: malicious",
         ]);
 
-        $clientIp = $config->detectClientIp();
+        $clientIp = $config->getClientIp();
         $this->assertNotNull($clientIp);
 
         // CRLF should be stripped
@@ -127,7 +127,7 @@ class EdgeCasesTest extends TestCase
             'client_user_agent' => "MyApp/1.0\0malicious",
         ]);
 
-        $userAgent = $config->detectClientUserAgent();
+        $userAgent = $config->getClientUserAgent();
         $this->assertNotNull($userAgent);
 
         // Null byte should be stripped

--- a/tests/GuzzleHttpClientTest.php
+++ b/tests/GuzzleHttpClientTest.php
@@ -450,4 +450,285 @@ class GuzzleHttpClientTest extends TestCase
         $this->assertEquals('fr', $headers['Accept-Language']);
         $this->assertEquals('devapp-key-abc', $headers['x-devapp']);
     }
+
+    /**
+     * Test that per-call bearer_token option is extracted and converted to Authorization header.
+     */
+    public function testPerCallBearerTokenOption(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    // Verify bearer_token was converted to Authorization header
+                    return isset($options['headers']['Authorization'])
+                        && $options['headers']['Authorization'] === 'Bearer per-call-token-123'
+                        && !isset($options['bearer_token']); // Original key should be removed
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', ['bearer_token' => 'per-call-token-123']);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call language option is extracted and converted to Accept-Language header.
+     */
+    public function testPerCallLanguageOption(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Accept-Language'])
+                        && $options['headers']['Accept-Language'] === 'it'
+                        && !isset($options['language']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', ['language' => 'it']);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call session_id option is extracted and converted to x-sid header.
+     */
+    public function testPerCallSessionIdOption(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['x-sid'])
+                        && $options['headers']['x-sid'] === 'session-abc-123'
+                        && !isset($options['session_id']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', ['session_id' => 'session-abc-123']);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call client_ip option is extracted and converted to Client-Ip header.
+     */
+    public function testPerCallClientIpOption(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Client-Ip'])
+                        && $options['headers']['Client-Ip'] === '192.168.1.100'
+                        && !isset($options['client_ip']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', ['client_ip' => '192.168.1.100']);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call client_user_agent option is extracted and converted to User-Agent header.
+     */
+    public function testPerCallClientUserAgentOption(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['User-Agent'])
+                        && $options['headers']['User-Agent'] === 'Mozilla/5.0 Custom'
+                        && !isset($options['client_user_agent']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', ['client_user_agent' => 'Mozilla/5.0 Custom']);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that multiple per-call options are extracted together.
+     */
+    public function testMultiplePerCallOptions(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Authorization'])
+                        && $options['headers']['Authorization'] === 'Bearer token-xyz'
+                        && isset($options['headers']['Accept-Language'])
+                        && $options['headers']['Accept-Language'] === 'fr'
+                        && isset($options['headers']['x-sid'])
+                        && $options['headers']['x-sid'] === 'sess-999'
+                        && isset($options['headers']['Client-Ip'])
+                        && $options['headers']['Client-Ip'] === '10.0.0.1'
+                        && isset($options['headers']['User-Agent'])
+                        && $options['headers']['User-Agent'] === 'TestApp/2.0'
+                        // Original keys should be removed
+                        && !isset($options['bearer_token'])
+                        && !isset($options['language'])
+                        && !isset($options['session_id'])
+                        && !isset($options['client_ip'])
+                        && !isset($options['client_user_agent']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', [
+            'bearer_token' => 'token-xyz',
+            'language' => 'fr',
+            'session_id' => 'sess-999',
+            'client_ip' => '10.0.0.1',
+            'client_user_agent' => 'TestApp/2.0',
+        ]);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call options are merged with existing headers in options.
+     */
+    public function testPerCallOptionsMergeWithExistingHeaders(): void
+    {
+        $responseData = ['success' => true];
+        $response = new Response(200, [], (string) json_encode($responseData));
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    // Custom header should be preserved
+                    return isset($options['headers']['X-Custom-Header'])
+                        && $options['headers']['X-Custom-Header'] === 'custom-value'
+                        // Per-call options should be added
+                        && isset($options['headers']['Authorization'])
+                        && $options['headers']['Authorization'] === 'Bearer per-call-token';
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->request('GET', 'test', [
+            'headers' => ['X-Custom-Header' => 'custom-value'],
+            'bearer_token' => 'per-call-token',
+        ]);
+
+        $this->assertEquals($responseData, $result);
+    }
+
+    /**
+     * Test that per-call options work with requestRaw() method too.
+     */
+    public function testPerCallOptionsInRequestRaw(): void
+    {
+        $response = new Response(200, [], 'raw content');
+
+        $mockGuzzle = $this->createMock(GuzzleClient::class);
+        $mockGuzzle->expects($this->once())
+            ->method('request')
+            ->with(
+                'GET',
+                'test',
+                $this->callback(function ($options) {
+                    return isset($options['headers']['Authorization'])
+                        && $options['headers']['Authorization'] === 'Bearer raw-token'
+                        && !isset($options['bearer_token']);
+                })
+            )
+            ->willReturn($response);
+
+        $reflection = new \ReflectionClass($this->httpClient);
+        $clientProperty = $reflection->getProperty('client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($this->httpClient, $mockGuzzle);
+
+        $result = $this->httpClient->requestRaw('GET', 'test', ['bearer_token' => 'raw-token']);
+
+        $this->assertSame($response, $result);
+    }
 }


### PR DESCRIPTION
Introduce support for passing request-specific parameters as per-call options, enhancing the SDK's usability in a stateless manner. Deprecate existing setter methods to prevent state leakage between requests. This change aligns with the design pattern used in the Stripe SDK. Breaking changes include deprecation warnings for several methods.