### PR TITLE
Update CHANGELOG and UPGRADE guide for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-02-05
+
+### Added
+
+- **Stateless Per-Call Options**: Pass request-specific parameters directly in `$options` instead of mutating client state
+  - `bearer_token`: Override Authorization header for single request
+  - `language`: Override Accept-Language for single request
+  - `session_id`: Override x-sid header for single request
+  - `client_ip`: Set Client-Ip header for single request
+  - `client_user_agent`: Set User-Agent for single request
+- Pattern inspired by Stripe SDK's `stripe_account` per-request option
+- Full test coverage for per-call options in `GuzzleHttpClientTest.php`
+
+### Deprecated
+
+- `setAccessToken()`: Use `['bearer_token' => $token]` in per-call options
+- `setSessionId()`: Use `['session_id' => $sid]` in per-call options
+- `setLanguage()`: Use `['language' => $lang]` in per-call options
+- `setAccept()`: Use `['headers' => ['Accept' => $accept]]` in per-call options
+- `setClientUserAgent()`: Use `['client_user_agent' => $ua]` in per-call options
+- `setClientIp()`: Use `['client_ip' => $ip]` in per-call options
+
+### Changed
+
+- Remove `$_SERVER` auto-detection for `client_ip` and `client_user_agent` in Configuration
+- Deprecation warnings via `trigger_error(E_USER_DEPRECATED)` for all deprecated setters
+
+### Notes
+
+- **Worker-Mode Safe**: SDK can now be used as singleton in FrankenPHP/Swoole without state leakage
+- **Backward Compatible**: Deprecated setters still work, just emit deprecation warnings
+- **Migration Path**: See UPGRADE.md for step-by-step migration guide
+
+---
+
 ## [1.3.0] - 2026-01-14
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,77 @@
+# Upgrade Guide
+
+## Upgrading to v1.4.0
+
+### Breaking Changes
+
+None. All existing code continues to work.
+
+### Deprecations
+
+The following setter methods now emit `E_USER_DEPRECATED` warnings:
+
+| Deprecated Method | Replacement |
+|-------------------|-------------|
+| `setAccessToken($token)` | `['bearer_token' => $token]` |
+| `setSessionId($sid)` | `['session_id' => $sid]` |
+| `setLanguage($lang)` | `['language' => $lang]` |
+| `setAccept($accept)` | `['headers' => ['Accept' => $accept]]` |
+| `setClientUserAgent($ua)` | `['client_user_agent' => $ua]` |
+| `setClientIp($ip)` | `['client_ip' => $ip]` |
+
+### Why This Change?
+
+The setter methods mutate client state, which causes **state leakage** in long-running
+processes like FrankenPHP worker mode. Per-call options are stateless and safe.
+
+### Migration Examples
+
+#### Before (v1.3.x)
+
+```php
+$client = new Client(['url' => '...', 'key' => '...']);
+
+// State mutation - unsafe in worker mode
+$client->setAccessToken($userToken);
+$client->setClientIp($_SERVER['REMOTE_ADDR']);
+$client->setLanguage('it');
+
+$data = $client->get('customers');
+```
+
+#### After (v1.4.0+)
+
+```php
+$client = new Client(['url' => '...', 'key' => '...']);
+
+// Stateless - safe in worker mode
+$data = $client->get('customers', [
+    'bearer_token' => $userToken,
+    'client_ip' => $_SERVER['REMOTE_ADDR'],
+    'language' => 'it'
+]);
+```
+
+### Suppressing Deprecation Warnings
+
+If you can't migrate immediately, suppress warnings:
+
+```php
+// Temporarily suppress (not recommended)
+@$client->setAccessToken($token);
+
+// Or via error handler
+set_error_handler(function($errno, $errstr) {
+    if (str_contains($errstr, 'deprecated since Swotto')) {
+        return true; // suppress
+    }
+    return false;
+}, E_USER_DEPRECATED);
+```
+
+### Timeline
+
+- **v1.4.0**: Setters deprecated with warnings
+- **v2.0.0** (future): Setters will be removed
+
+We recommend migrating to per-call options as soon as possible.


### PR DESCRIPTION
Introduce per-call options for stateless API requests and deprecate existing setter methods to prevent state leakage in long-running processes. Update documentation to reflect these changes and provide migration guidance.