### PR TITLE
feat!: v2.1.0 - Rename Client to SwottoClient (Stripe naming convention)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-02-06
+
+### Breaking Changes
+
+- **`Client` renamed to `SwottoClient`**: `Swotto\Client` → `Swotto\SwottoClient`
+- **`ClientInterface` renamed to `SwottoClientInterface`**: `Swotto\Contract\ClientInterface` → `Swotto\Contract\SwottoClientInterface`
+
+### Changed
+
+- Client classes now follow Stripe PHP SDK naming convention (brand prefix on public API classes)
+- All internal references, tests, and documentation updated
+
+### Migration
+
+Search and replace in your codebase:
+- `use Swotto\Client` → `use Swotto\SwottoClient`
+- `use Swotto\Contract\ClientInterface` → `use Swotto\Contract\SwottoClientInterface`
+- `new Client(` → `new SwottoClient(`
+
+See [UPGRADE.md](UPGRADE.md) for detailed migration guide.
+
+---
+
 ## [2.0.0] - 2026-02-05
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ composer require agenziasmart/swotto
 <?php
 require_once 'vendor/autoload.php';
 
-use Swotto\Client;
+use Swotto\SwottoClient;
 
 // Initialize the client
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
 ]);
@@ -83,7 +83,7 @@ Swotto supports **dual authentication** to identify both your application and en
 Identifies your third-party application to SW4. **Required for all requests.**
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
 ]);
@@ -91,7 +91,7 @@ $client = new Client([
 
 > **Security Note**: Never commit DevApp tokens to version control. Use environment variables:
 > ```php
-> $client = new Client([
+> $client = new SwottoClient([
 >     'url' => $_ENV['SW4_API_URL'],
 >     'key' => $_ENV['SW4_DEVAPP_TOKEN'],
 > ]);
@@ -103,7 +103,7 @@ Authenticates specific end users within your application. Can be set as default 
 
 ```php
 // Option A: Config default (applied to every request)
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'bearer_token' => $userBearerToken,
@@ -119,7 +119,7 @@ $orders = $client->get('orders', [
 
 ```php
 // 1. Initialize with DevApp token and user context
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'client_ip' => $_SERVER['REMOTE_ADDR'],
@@ -133,7 +133,7 @@ $loginResponse = $client->post('auth/login', [
 ]);
 
 // 3. Create authenticated client with Bearer token
-$authClient = new Client([
+$authClient = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'bearer_token' => $loginResponse['data']['token'],
@@ -149,7 +149,7 @@ $customers = $authClient->get('customers');
 **For FrankenPHP/Swoole workers**, use per-call options instead:
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
 ]);
@@ -237,7 +237,7 @@ $client->downloadToFile('exports/large-dataset.csv', '/path/to/data.csv');
 Automatic retry for transient errors with configurable backoff:
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
 
@@ -267,7 +267,7 @@ $client = new Client([
 Pass request-specific parameters directly in options:
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
 ]);
@@ -302,7 +302,7 @@ $ordersB = $client->get('orders', [
 Set context options in config as defaults. Per-call options override defaults.
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'bearer_token' => 'default-token',  // applied to every request
@@ -451,7 +451,7 @@ try {
 ### Complete Example
 
 ```php
-$client = new Client([
+$client = new SwottoClient([
     // Required
     'url' => 'https://api.sw4.it',
 
@@ -483,7 +483,7 @@ Run the test suite:
 composer test
 
 # Run specific tests
-composer test -- --filter ClientTest
+composer test -- --filter SwottoClientTest
 
 # Code style check
 composer cs
@@ -519,7 +519,7 @@ PHP 8.3 or higher.
 Inject a PSR-3 logger in the constructor:
 
 ```php
-$client = new Client($config, $yourPsr3Logger);
+$client = new SwottoClient($config, $yourPsr3Logger);
 ```
 
 ### Can I use this with Laravel/Symfony/other frameworks?

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,44 @@
 # Upgrade Guide
 
+## Upgrading from v2.0.0 to v2.1.0
+
+v2.1.0 renames the client classes to follow the Stripe PHP SDK naming convention (brand prefix on public API classes).
+
+### Class Renames
+
+| v2.0.0 | v2.1.0 |
+|--------|--------|
+| `Swotto\Client` | `Swotto\SwottoClient` |
+| `Swotto\Contract\ClientInterface` | `Swotto\Contract\SwottoClientInterface` |
+
+### Migration
+
+Search and replace in your codebase:
+
+```php
+// v2.0.0
+use Swotto\Client;
+use Swotto\Contract\ClientInterface;
+
+$client = new SwottoClient([...]);
+
+// v2.1.0
+use Swotto\SwottoClient;
+use Swotto\Contract\SwottoClientInterface;
+
+$client = new SwottoClient([...]);
+```
+
+### Quick Migration Checklist
+
+- [ ] Replace `use Swotto\Client` with `use Swotto\SwottoClient`
+- [ ] Replace `use Swotto\Contract\ClientInterface` with `use Swotto\Contract\SwottoClientInterface`
+- [ ] Replace `new Client(` with `new SwottoClient(`
+- [ ] Update any type hints from `Client` to `SwottoClient` and `ClientInterface` to `SwottoClientInterface`
+- [ ] Run `composer cs-fix && composer phpstan && composer test`
+
+---
+
 ## Upgrading from v1.x to v2.0.0
 
 v2.0.0 is a major release with breaking changes. This guide covers every change and how to migrate.
@@ -15,14 +54,14 @@ v2.0.0 is a major release with breaking changes. This guide covers every change 
 
 ```php
 // v1.x
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'access_token' => $userToken,  // OLD
 ]);
 
 // v2.0.0
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'bearer_token' => $userToken,  // NEW
@@ -54,20 +93,20 @@ All setter methods have been removed. Use config defaults or per-call options in
 | `setAccept($accept)` | Not available (always `application/json`) |
 | `setClientUserAgent($ua)` | Config: `'client_user_agent' => $ua` or per-call: `['client_user_agent' => $ua]` |
 | `setClientIp($ip)` | Config: `'client_ip' => $ip` or per-call: `['client_ip' => $ip]` |
-| `setLogger($logger)` | Pass logger in constructor: `new Client($config, $logger)` |
+| `setLogger($logger)` | Pass logger in constructor: `new SwottoClient($config, $logger)` |
 
 #### Migration Example
 
 ```php
 // v1.x - Mutable state
-$client = new Client(['url' => '...', 'key' => '...']);
+$client = new SwottoClient(['url' => '...', 'key' => '...']);
 $client->setAccessToken($userToken);
 $client->setLanguage('it');
 $client->setClientIp($_SERVER['REMOTE_ADDR']);
 $data = $client->get('customers');
 
 // v2.0.0 Option A - Config defaults (applied to every request)
-$client = new Client([
+$client = new SwottoClient([
     'url' => '...',
     'key' => '...',
     'bearer_token' => $userToken,
@@ -77,7 +116,7 @@ $client = new Client([
 $data = $client->get('customers');
 
 // v2.0.0 Option B - Per-call options (per-request, overrides defaults)
-$client = new Client(['url' => '...', 'key' => '...']);
+$client = new SwottoClient(['url' => '...', 'key' => '...']);
 $data = $client->get('customers', [
     'bearer_token' => $userToken,
     'language' => 'it',
@@ -141,7 +180,7 @@ try {
 }
 
 // v2.0.0 - Use Retry instead (built-in), or implement CB externally
-$client = new Client([
+$client = new SwottoClient([
     'url' => '...',
     'key' => '...',
     'retry_enabled' => true,
@@ -196,7 +235,7 @@ v2.0.0 introduces the Stripe-inspired default options pattern:
 
 ```php
 // Config-level defaults are merged with per-call options
-$client = new Client([
+$client = new SwottoClient([
     'url' => 'https://api.sw4.it',
     'key' => 'YOUR_DEVAPP_TOKEN',
     'bearer_token' => 'default-token',   // applied to every request

--- a/src/Contract/SwottoClientInterface.php
+++ b/src/Contract/SwottoClientInterface.php
@@ -7,12 +7,12 @@ namespace Swotto\Contract;
 use Swotto\Response\SwottoResponse;
 
 /**
- * Interface ClientInterface.
+ * Interface SwottoClientInterface.
  *
  * Defines the contract for Swotto API Client.
  * 12 methods: 5 HTTP verbs, 4 file upload, 2 advanced, 1 health.
  */
-interface ClientInterface
+interface SwottoClientInterface
 {
     /**
      * Send a GET request.

--- a/src/SwottoClient.php
+++ b/src/SwottoClient.php
@@ -8,19 +8,19 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Swotto\Config\Configuration;
-use Swotto\Contract\ClientInterface;
 use Swotto\Contract\HttpClientInterface;
+use Swotto\Contract\SwottoClientInterface;
 use Swotto\Exception\ConnectionException;
 use Swotto\Http\GuzzleHttpClient;
 use Swotto\Response\SwottoResponse;
 
 /**
- * Client.
+ * SwottoClient.
  *
  * Main Swotto API Client implementation.
  * Immutable, worker-safe. Uses defaultOptions + merge pattern (Stripe-inspired).
  */
-final class Client implements ClientInterface
+final class SwottoClient implements SwottoClientInterface
 {
     private readonly HttpClientInterface $httpClient;
 

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -9,13 +9,13 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Swotto\Client;
 use Swotto\Config\Configuration;
 use Swotto\Contract\HttpClientInterface;
 use Swotto\Exception\ApiException;
 use Swotto\Exception\RateLimitException;
 use Swotto\Http\GuzzleHttpClient;
 use Swotto\Response\SwottoResponse;
+use Swotto\SwottoClient;
 
 /**
  * EdgeCasesTest.
@@ -52,7 +52,7 @@ class EdgeCasesTest extends TestCase
             ->method('request')
             ->willReturn(['data' => $unicodeData]);
 
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -292,7 +292,7 @@ class EdgeCasesTest extends TestCase
             ->with('GET', $longPath, $this->anything())
             ->willReturn(['data' => 'ok']);
 
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -315,7 +315,7 @@ class EdgeCasesTest extends TestCase
             ->with('GET', $specialPath, $this->anything())
             ->willReturn(['data' => 'ok']);
 
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient

--- a/tests/SwottoClientDefaultOptionsTest.php
+++ b/tests/SwottoClientDefaultOptionsTest.php
@@ -6,17 +6,17 @@ namespace Swotto\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Swotto\Client;
 use Swotto\Contract\HttpClientInterface;
+use Swotto\SwottoClient;
 
 /**
- * ClientDefaultOptionsTest.
+ * SwottoClientDefaultOptionsTest.
  *
  * Tests for the defaultOptions + merge pattern (Stripe-inspired).
  * Verifies that config-level context options (bearer_token, language, session_id,
  * client_ip, client_user_agent) are extracted as defaults and merged with per-call options.
  */
-class ClientDefaultOptionsTest extends TestCase
+class SwottoClientDefaultOptionsTest extends TestCase
 {
     private HttpClientInterface $mockHttpClient;
 
@@ -30,7 +30,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testDefaultBearerTokenIsPassedOnEveryRequest(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'bearer_token' => 'default-token-123'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -46,7 +46,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testDefaultLanguageIsPassedOnEveryRequest(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'language' => 'it'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -62,7 +62,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testPerCallOptionOverridesDefault(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'bearer_token' => 'default-token'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -79,7 +79,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testNoDefaultsNoPerCallMeansEmptyOptions(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -95,7 +95,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testMultipleDefaultsMergedWithPerCall(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             [
                 'url' => 'https://api.example.com',
                 'bearer_token' => 'default-token',
@@ -126,7 +126,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testDefaultOptionsAreImmutable(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'bearer_token' => 'immutable-token'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -149,7 +149,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testEmptyBearerTokenNotIncludedInDefaults(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'bearer_token' => ''],
             $this->mockLogger,
             $this->mockHttpClient
@@ -166,7 +166,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testDefaultOptionsForPostWithData(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             ['url' => 'https://api.example.com', 'bearer_token' => 'post-token'],
             $this->mockLogger,
             $this->mockHttpClient
@@ -190,7 +190,7 @@ class ClientDefaultOptionsTest extends TestCase
 
     public function testDefaultClientIpAndUserAgent(): void
     {
-        $client = new Client(
+        $client = new SwottoClient(
             [
                 'url' => 'https://api.example.com',
                 'client_ip' => '192.168.1.1',

--- a/tests/SwottoClientFileUploadTest.php
+++ b/tests/SwottoClientFileUploadTest.php
@@ -8,28 +8,28 @@ use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
-use Swotto\Client;
 use Swotto\Contract\HttpClientInterface;
+use Swotto\SwottoClient;
 
 /**
- * ClientFileUploadTest.
+ * SwottoClientFileUploadTest.
  *
  * Test file upload methods: postFile, postFiles, putFile, patchFile.
  */
-class ClientFileUploadTest extends TestCase
+class SwottoClientFileUploadTest extends TestCase
 {
     private HttpClientInterface $mockHttpClient;
 
     private LoggerInterface $mockLogger;
 
-    private Client $client;
+    private SwottoClient $client;
 
     protected function setUp(): void
     {
         $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
         $this->mockLogger = $this->createMock(LoggerInterface::class);
 
-        $this->client = new Client(
+        $this->client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient

--- a/tests/SwottoClientMethodsTest.php
+++ b/tests/SwottoClientMethodsTest.php
@@ -8,17 +8,17 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
-use Swotto\Client;
 use Swotto\Contract\HttpClientInterface;
 use Swotto\Response\SwottoResponse;
+use Swotto\SwottoClient;
 
-class ClientMethodsTest extends TestCase
+class SwottoClientMethodsTest extends TestCase
 {
     private HttpClientInterface $mockHttpClient;
 
     private LoggerInterface $mockLogger;
 
-    private Client $client;
+    private SwottoClient $client;
 
     private string $tempDir;
 
@@ -27,7 +27,7 @@ class ClientMethodsTest extends TestCase
         $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
         $this->mockLogger = $this->createMock(LoggerInterface::class);
 
-        $this->client = new Client(
+        $this->client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient

--- a/tests/SwottoClientTest.php
+++ b/tests/SwottoClientTest.php
@@ -6,25 +6,25 @@ namespace Swotto\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Swotto\Client;
 use Swotto\Contract\HttpClientInterface;
 use Swotto\Exception\ConnectionException;
 use Swotto\Exception\ValidationException;
+use Swotto\SwottoClient;
 
-class ClientTest extends TestCase
+class SwottoClientTest extends TestCase
 {
     private HttpClientInterface $mockHttpClient;
 
     private LoggerInterface $mockLogger;
 
-    private Client $client;
+    private SwottoClient $client;
 
     protected function setUp(): void
     {
         $this->mockHttpClient = $this->createMock(HttpClientInterface::class);
         $this->mockLogger = $this->createMock(LoggerInterface::class);
 
-        $this->client = new Client(
+        $this->client = new SwottoClient(
             ['url' => 'https://api.example.com'],
             $this->mockLogger,
             $this->mockHttpClient


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Renamed `Client` to `SwottoClient` and `ClientInterface` to `SwottoClientInterface` following the Stripe PHP SDK naming convention (`StripeClient`, `StripeClientInterface`)
- Renamed 6 files (2 source + 4 test files) and updated all references across 10 files
- Updated CHANGELOG.md, README.md, and UPGRADE.md with v2.1.0 migration guide
- Quality gate passed: cs-fix 0 issues, phpstan Level 8 clean, 222 tests / 743 assertions all green

## Changes

### Renamed Files
- `src/Client.php` -> `src/SwottoClient.php`
- `src/Contract/ClientInterface.php` -> `src/Contract/SwottoClientInterface.php`
- `tests/ClientTest.php` -> `tests/SwottoClientTest.php`
- `tests/ClientDefaultOptionsTest.php` -> `tests/SwottoClientDefaultOptionsTest.php`
- `tests/ClientFileUploadTest.php` -> `tests/SwottoClientFileUploadTest.php`
- `tests/ClientMethodsTest.php` -> `tests/SwottoClientMethodsTest.php`

### Updated References
- All internal class references updated (`Client` -> `SwottoClient`, `ClientInterface` -> `SwottoClientInterface`)
- README.md usage examples updated
- UPGRADE.md migration guide with search-and-replace instructions
- CHANGELOG.md v2.1.0 section added

## Breaking Change

Users must update their code:
```php
// Before (v2.0.x)
use Swotto\Client;
$client = new Client([...]);

// After (v2.1.0)
use Swotto\SwottoClient;
$client = new SwottoClient([...]);
```

## Test plan

- [x] `composer cs-fix` - 0 issues
- [x] `composer phpstan` - Level 8 clean
- [x] `composer test` - 222 tests, 743 assertions, all passing
- [ ] Verify Packagist update after release tag